### PR TITLE
remove specified timeout in favor of default 

### DIFF
--- a/core/main.pl
+++ b/core/main.pl
@@ -14,7 +14,6 @@ print color("blue");
 
 $ua = LWP::UserAgent->new(ssl_opts => { verify_hostname => 0 });
 $ua->protocols_allowed( [ 'http','https'] );
-$ua->timeout(15);
 $ua->agent('Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36');
 $ua->requests_redirectable(undef);
 


### PR DESCRIPTION
Sometimes people do recon through Tor, or a VPN, or a tethered internet, or some distant AP they've broken into. Errors in any level of transmission can cause delay. Adding layers to hide yourself cause delay. 15 seconds is too short and can cause operations to be lost. Best this be left at 180 second (the default). If our replies aren't coming back after 180 seconds things deserve to be dropped. 180 second is an eternity.

Unless one of your exploit checks are time-critical (last I checked none are), less arguments in LWP::UserAgent is sometimes better and this is one case where thats so.
